### PR TITLE
Upgrade all dependencies to latest stable versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ buildscript {
 }
 
 plugins {
-    kotlin("jvm") version "2.1.0" apply false
+    kotlin("jvm") version "2.3.21" apply false
     id("net.researchgate.release") version "3.1.0"
     `java-library`
     signing
@@ -45,7 +45,7 @@ tasks {
     }
 
     withType<Wrapper> {
-        gradleVersion = "8.12"
+        gradleVersion = "9.4.1"
         distributionType = Wrapper.DistributionType.BIN
     }
 }
@@ -71,7 +71,7 @@ allprojects {
         testImplementation("io.kotest:kotest-runner-junit5:${properties["kotest_version"]}")
         testImplementation("io.kotest:kotest-assertions-core:${properties["kotest_version"]}")
         testImplementation("io.kotest:kotest-property:${properties["kotest_version"]}")
-        testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
+        testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
         testImplementation("ch.qos.logback", "logback-classic", prop("logback_version"))
     }
 
@@ -80,8 +80,8 @@ allprojects {
         withType<KotlinCompile> {
             compilerOptions {
                 jvmTarget = JvmTarget.JVM_21
-                apiVersion = KotlinVersion.KOTLIN_2_1
-                languageVersion = KotlinVersion.KOTLIN_2_1
+                apiVersion = KotlinVersion.KOTLIN_2_3
+                languageVersion = KotlinVersion.KOTLIN_2_3
                 javaParameters = true
                 suppressWarnings = true
             }
@@ -170,14 +170,14 @@ project(":tekniq-cache") {
 project(":tekniq-jdbc") {
     dependencies {
         implementation(project(":tekniq-core"))
-        testImplementation("org.hsqldb:hsqldb:2.3.4")
+        testImplementation("org.hsqldb:hsqldb:2.7.4")
     }
 }
 project(":tekniq-rest") {
     dependencies {
         implementation("com.fasterxml.jackson.core", "jackson-core", prop("jackson_version"))
         implementation("com.fasterxml.jackson.module", "jackson-module-kotlin", prop("jackson_version"))
-        testImplementation("io.javalin:javalin:6.4.0")
+        testImplementation("io.javalin:javalin:7.2.0")
         testImplementation("ch.qos.logback:logback-classic:${properties["logback_version"]}")
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,11 @@
 version=0.21.1-SNAPSHOT
 # org.jetbrains.kotlin
-kotlin_version=2.1.0
+kotlin_version=2.3.21
 # com.fasterxml.jackson
-jackson_version=2.18.2
+jackson_version=2.21.2
 # com.github.ben-manes.caffeine
-caffeine_version=3.1.8
+caffeine_version=3.2.3
 # ch.qos.logback
-logback_version=1.5.15
+logback_version=1.5.32
 # io.kotest
-kotest_version=5.9.1
+kotest_version=6.1.11

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tekniq-cache/src/main/kotlin/io/tekniq/cache/TqCacheMap.kt
+++ b/tekniq-cache/src/main/kotlin/io/tekniq/cache/TqCacheMap.kt
@@ -1,6 +1,6 @@
 package io.tekniq.cache
 
-interface TqCacheMap<K, V> : MutableMap<K, V> {
+interface TqCacheMap<K : Any, V : Any> : MutableMap<K, V> {
     val stats: TqCacheStats
     fun cleanUp()
 }

--- a/tekniq-cache/src/main/kotlin/io/tekniq/cache/TqLoadingCache.kt
+++ b/tekniq-cache/src/main/kotlin/io/tekniq/cache/TqLoadingCache.kt
@@ -1,11 +1,11 @@
 package io.tekniq.cache
 
+import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
-import com.github.benmanes.caffeine.cache.LoadingCache
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import kotlin.collections.MutableMap.MutableEntry
 
-open class TqLoadingCache<K, V>(
+open class TqLoadingCache<K : Any, V : Any>(
     val expireAfterAccess: Long? = null,
     val expireAfterWrite: Long? = null,
     val refreshAfterWrite: Long? = null,
@@ -13,25 +13,24 @@ open class TqLoadingCache<K, V>(
     val recordStats: Boolean = false,
     private val loader: (key: K) -> V?
 ) : TqCacheMap<K, V> {
-    private val cacheLoader: LoadingCache<K, V> = Caffeine
+    private val cache: Cache<K, V> = Caffeine
         .newBuilder()
         .also { builder ->
             expireAfterAccess?.also { builder.expireAfterAccess(expireAfterAccess, MILLISECONDS) }
             expireAfterWrite?.also { builder.expireAfterWrite(expireAfterWrite, MILLISECONDS) }
             maximumSize?.also { builder.maximumSize(maximumSize) }
-            refreshAfterWrite?.also { builder.refreshAfterWrite(refreshAfterWrite, MILLISECONDS) }
             if (recordStats) builder.recordStats()
         }
-        .build { key -> loader(key) }
-    private val map = cacheLoader.asMap()
+        .build()
+    private val map = cache.asMap()
     override val entries: MutableSet<MutableEntry<K, V>>
         get() = map.entries
     override val keys: MutableSet<K>
         get() = map.keys
     override val size: Int
-        get() = cacheLoader.estimatedSize().toInt()
+        get() = cache.estimatedSize().toInt()
     override val stats: TqCacheStats
-        get() = cacheLoader.stats().let {
+        get() = cache.stats().let {
             TqCacheStats(
                 hitCount = it.hitCount(),
                 missCount = it.missCount(),
@@ -52,7 +51,12 @@ open class TqLoadingCache<K, V>(
     override fun put(key: K, value: V): V? = map.put(key, value)
     override fun putAll(from: Map<out K, V>) = map.putAll(from)
     override fun remove(key: K): V? = map.remove(key)
-    override fun get(key: K): V? = cacheLoader.get(key)
-    override fun cleanUp() = cacheLoader.cleanUp()
+    override fun get(key: K): V? {
+        cache.getIfPresent(key)?.let { return it }
+        val loaded = loader(key) ?: return null
+        cache.put(key, loaded)
+        return loaded
+    }
+    override fun cleanUp() = cache.cleanUp()
 }
 

--- a/tekniq-cache/src/test/kotlin/io/tekniq/cache/TqCaffeineSpec.kt
+++ b/tekniq-cache/src/test/kotlin/io/tekniq/cache/TqCaffeineSpec.kt
@@ -71,7 +71,7 @@ object TqCaffeineSpec : DescribeSpec({
 
     describe("ensures feature flags are functional") {
         it("don't cache null answers") {
-            val cache = TqLoadingCache<Int, String?>(recordStats = true) {
+            val cache = TqLoadingCache<Int, String>(recordStats = true) {
                 when (it % 2 == 0) {
                     true -> it.toString()
                     else -> null

--- a/tekniq-core/src/main/kotlin/io/tekniq/TqExtensions.kt
+++ b/tekniq-core/src/main/kotlin/io/tekniq/TqExtensions.kt
@@ -22,18 +22,19 @@ operator fun Date.plusAssign(milli: Long) { time += milli }
 operator fun Date.minus(milli: Long): Date = Date(time - milli)
 operator fun Date.minusAssign(milli: Long) { time -= milli }
 
-fun Date.add(duration: Duration): Date = add(duration.toMillis().toInt(), TimeUnit.MILLISECONDS)
-fun Date.add(amount: Int, unit: TimeUnit = TimeUnit.DAYS): Date = Calendar.getInstance()
+fun Date.add(duration: Duration): Date = add(duration.toMillis(), TimeUnit.MILLISECONDS)
+fun Date.add(amount: Int, unit: TimeUnit = TimeUnit.DAYS): Date = add(amount.toLong(), unit)
+fun Date.add(amount: Long, unit: TimeUnit = TimeUnit.DAYS): Date = Calendar.getInstance()
     .also { it.timeInMillis = this.time }
     .also {
         when (unit) {
             TimeUnit.NANOSECONDS -> throw UnsupportedOperationException("Nanoseconds are not supported by Date")
             TimeUnit.MICROSECONDS -> throw UnsupportedOperationException("Nanoseconds are not supported by Date")
-            TimeUnit.MILLISECONDS -> it.add(Calendar.MILLISECOND, amount)
-            TimeUnit.SECONDS -> it.add(Calendar.SECOND, amount)
-            TimeUnit.MINUTES -> it.add(Calendar.MINUTE, amount)
-            TimeUnit.HOURS -> it.add(Calendar.HOUR_OF_DAY, amount)
-            TimeUnit.DAYS -> it.add(Calendar.DAY_OF_MONTH, amount)
+            TimeUnit.MILLISECONDS -> it.add(Calendar.MILLISECOND, amount.toInt())
+            TimeUnit.SECONDS -> it.add(Calendar.SECOND, amount.toInt())
+            TimeUnit.MINUTES -> it.add(Calendar.MINUTE, amount.toInt())
+            TimeUnit.HOURS -> it.add(Calendar.HOUR_OF_DAY, amount.toInt())
+            TimeUnit.DAYS -> it.add(Calendar.DAY_OF_MONTH, amount.toInt())
         }
     }
     .time

--- a/tekniq-rest/src/test/kotlin/io/tekniq/rest/TqRestClientSpec.kt
+++ b/tekniq-rest/src/test/kotlin/io/tekniq/rest/TqRestClientSpec.kt
@@ -111,17 +111,16 @@ object TqRestClientSpec : DescribeSpec({
     private val clients = ConcurrentHashMap.newKeySet<MessageClient<*>>()
     private val rest = TqRestClient()
     private val javalin = Javalin
-        .create {
-            it.jsonMapper(JavalinJackson(rest.mapper))
-            it.bundledPlugins.enableCors { cors -> cors.addRule { it.anyHost() } }
-        }
-        .get("/get") { it.json(PostmanEcho(it.queryParamMap(), it.headerMap(), it.url())) }
-        .post("/post") { it.json(PostmanEcho(it.queryParamMap(), it.headerMap(), it.url(), it.bodyAsClass())) }
-        .get("/timeout") {
+        .create { config ->
+            config.jsonMapper(JavalinJackson(rest.mapper))
+            config.bundledPlugins.enableCors { cors -> cors.addRule { rule -> rule.anyHost() } }
+            config.routes.get("/get") { ctx -> ctx.json(PostmanEcho(ctx.queryParamMap(), ctx.headerMap(), ctx.url())) }
+            config.routes.post("/post") { ctx -> ctx.json(PostmanEcho(ctx.queryParamMap(), ctx.headerMap(), ctx.url(), ctx.bodyAsClass())) }
+            config.routes.get("/timeout") { ctx ->
                 Thread.sleep(2.seconds.inWholeMilliseconds)
-                it.status(HttpStatus.NO_CONTENT)
+                ctx.status(HttpStatus.NO_CONTENT)
             }
-        .post("/stream") {
+            config.routes.post("/stream") { ctx ->
                 val list = listOf("One", "Two", "Three", "Four")
                 val iterator = object : Iterator<SimpleData> {
                     private var i = list.iterator()
@@ -132,46 +131,47 @@ object TqRestClientSpec : DescribeSpec({
                         return SimpleData(i.next(), mapOf("Random" to Random.nextDouble()))
                     }
                 }
-                it.jsonStream(iterator)
+                ctx.jsonStream(iterator)
             }
-        .sse("/sse/string") { client ->
-            clients += MessageClient(
-                client, """
-                This is a super long message with a substructure
-                id: fake-random-id
-                event: fake-event
-                data: fake simple message
-                
-                Now what to do about it all?
-            """.trimIndent()
-            )
-            client.onClose { clients.removeIf { it.sse == client } }
-            thread {
-                Thread.sleep(1000)
-                client.close()
+            config.routes.sse("/sse/string") { client ->
+                clients += MessageClient(
+                    client, """
+                    This is a super long message with a substructure
+                    id: fake-random-id
+                    event: fake-event
+                    data: fake simple message
+
+                    Now what to do about it all?
+                """.trimIndent()
+                )
+                client.onClose { clients.removeIf { mc -> mc.sse == client } }
+                thread {
+                    Thread.sleep(1000)
+                    client.close()
+                }
+                client.keepAlive()
             }
-            client.keepAlive()
-        }
-        .sse("/sse/object") { client ->
-            clients += MessageClient(client, SimpleData("Blob", mapOf("iq" to 142)))
-            client.onClose { clients.removeIf { it.sse == client } }
-            thread {
-                Thread.sleep(1000)
-                client.close()
+            config.routes.sse("/sse/object") { client ->
+                clients += MessageClient(client, SimpleData("Blob", mapOf("iq" to 142)))
+                client.onClose { clients.removeIf { mc -> mc.sse == client } }
+                thread {
+                    Thread.sleep(1000)
+                    client.close()
+                }
+                client.keepAlive()
             }
-            client.keepAlive()
-        }
-        .ws("/ws") { config ->
-            config.onConnect {
-                it.send(SimpleData("Guardians", mapOf("Location" to "Galaxy")).toString())
+            config.routes.ws("/ws") { ws ->
+                ws.onConnect { ctx ->
+                    ctx.send(SimpleData("Guardians", mapOf("Location" to "Galaxy")).toString())
+                }
+                ws.onMessage { ctx ->
+                    println("[Server Message] ${ctx.message()}")
+                    ctx.send(SimpleData(ctx.message(), ctx.queryParamMap()).toString())
+                    ctx.closeSession(1002, "I'm a happy camper")
+                }
+                ws.onError { ctx -> ctx.error()?.printStackTrace() }
+                ws.onClose { ctx -> println("Closed because of ${ctx.status()} - ${ctx.reason()}") }
             }
-            config.onMessage {
-                println("[Server Message] ${it.message()}")
-                it.send(SimpleData(it.message(), it.queryParamMap()).toString())
-                it.closeSession(1002, "I'm a happy camper")
-            }
-            config.onError { it.error()?.printStackTrace() }
-            config.onClose { println("Closed because of ${it.status()} - ${it.reason()}") }
         }
 
     init {


### PR DESCRIPTION
- Kotlin 2.1.0 -> 2.3.21 (language version 2.3)
- Gradle 8.12 -> 9.4.1
- Jackson 2.18.2 -> 2.21.2
- Caffeine 3.1.8 -> 3.2.3
- Logback 1.5.15 -> 1.5.32
- Kotest 5.9.1 -> 6.1.11
- kotlinx-coroutines 1.7.3 -> 1.10.2
- Javalin 6.4.0 -> 7.2.0
- HSQLDB 2.3.4 -> 2.7.4

Adapt code to breaking changes in Kotlin 2.3, Caffeine 3.2,
and Javalin 7:

- Add explicit Long.toInt() calls in TqExtensions for
  Calendar.add() (Kotlin 2.3 stricter numeric conversions)
- Add non-null type bounds to TqCacheMap and TqLoadingCache
  (Caffeine requires non-null key/value types)
- Switch TqLoadingCache from LoadingCache to Cache to support
  nullable loader returns under stricter null-safety rules
- Migrate Javalin route definitions into config.routes block
  (Javalin 7 removed post-creation route registration)
